### PR TITLE
Updated reference to css/js scripts to use protocol-relative URL

### DIFF
--- a/foa-site.php
+++ b/foa-site.php
@@ -1482,8 +1482,8 @@ Class UBC_FOA_Theme_Options {
      * @return void
      */        
         function wp_head(){ ?>
-        <link rel="stylesheet" href="http://cdn.arts.ubc.ca/foa-cdn/css/slick.css" >
-        <link rel="stylesheet" href="http://cdn.arts.ubc.ca/foa-cdn/css/foa.css">
+        <link rel="stylesheet" href="//cdn.arts.ubc.ca/foa-cdn/css/slick.css" >
+        <link rel="stylesheet" href="//cdn.arts.ubc.ca/foa-cdn/css/foa.css">
         <style type="text/css" media="screen">
 
             .gradient-color{
@@ -1579,8 +1579,8 @@ Class UBC_FOA_Theme_Options {
                     jQuery("#news-ticker").vTicker();
                  });   
             </script>
-            <script src="http://cdn.arts.ubc.ca/foa-cdn/js/ticker.js"></script>
-            <script type="text/javascript" src="http://cdn.arts.ubc.ca/foa-cdn/js/slick.min.js"></script>
+            <script src="//cdn.arts.ubc.ca/foa-cdn/js/ticker.js"></script>
+            <script type="text/javascript" src="//cdn.arts.ubc.ca/foa-cdn/js/slick.min.js"></script>
             <?php
         }
     }


### PR DESCRIPTION
@richardtape As per our email discussion, here is the pull request to update the reference for the following files:
http://cdn.arts.ubc.ca/foa-cdn/js/ticker.js
http://cdn.arts.ubc.ca/foa-cdn/js/slick.min.js
http://cdn.arts.ubc.ca/foa-cdn/css/slick.css
http://cdn.arts.ubc.ca/foa-cdn/css/foa.css