### PR TITLE
Remove Facebook and Instagram from Social Row [INC1951830]

### DIFF
--- a/foa-site.php
+++ b/foa-site.php
@@ -692,14 +692,6 @@ Class UBC_FOA_Theme_Options {
 	            'value' => 'sr1-twitter',
 	            'label' => __( 'Twitter', 'arts-clf' )
 	        ),
-	        'sr1-instagram' => array(
-	            'value' => 'sr1-instagram',
-	            'label' => __( 'Instagram', 'arts-clf' )
-	        ),
-	        'sr1-facebook' => array(
-	            'value' => 'sr1-facebook',
-	            'label' => __( 'Facebook', 'arts-clf' )
-	        ),
 	        'sr1-flickr' => array(
 	            'value' => 'sr1-flickr',
 	            'label' => __( 'Flickr', 'arts-clf' )
@@ -730,14 +722,6 @@ Class UBC_FOA_Theme_Options {
 	        'sr2-twitter' => array(
 	            'value' => 'sr2-twitter',
 	            'label' => __( 'Twitter', 'arts-clf' )
-	        ),
-	        'sr2-instagram' => array(
-	            'value' => 'sr2-instagram',
-	            'label' => __( 'Instagram', 'arts-clf' )
-	        ),
-	        'sr2-facebook' => array(
-	            'value' => 'sr2-facebook',
-	            'label' => __( 'Facebook', 'arts-clf' )
 	        ),
 	        'sr2-flickr' => array(
 	            'value' => 'sr2-flickr',
@@ -770,14 +754,6 @@ Class UBC_FOA_Theme_Options {
 	        'sr3-twitter' => array(
 	            'value' => 'sr3-twitter',
 	            'label' => __( 'Twitter', 'arts-clf' )
-	        ),
-	        'sr3-instagram' => array(
-	            'value' => 'sr3-instagram',
-	            'label' => __( 'Instagram', 'arts-clf' )
-	        ),
-	        'sr3-facebook' => array(
-	            'value' => 'sr3-facebook',
-	            'label' => __( 'Facebook', 'arts-clf' )
 	        ),
 	        'sr3-flickr' => array(
 	            'value' => 'sr3-flickr',

--- a/foa-site.php
+++ b/foa-site.php
@@ -363,8 +363,6 @@ Class UBC_FOA_Theme_Options {
                 </div>
                 <div id="sr1-posts" class="sr1-element"><label>Choose a category</label><br><?php UBC_Collab_Theme_Options::select_categories('arts-social-column1-post-category'); ?></div>
                 <div id="sr1-twitter" class="sr1-element"><?php UBC_Collab_Theme_Options::text('arts-social-column1-twitter-widget-id', 'Twitter Widget ID'); ?><br><?php UBC_Collab_Theme_Options::text('arts-social-column1-twitter-user', 'Twitter User'); ?><br><?php UBC_Collab_Theme_Options::text('arts-social-column1-twitter-url', 'Twitter Page URL'); ?></div>
-                <div id="sr1-instagram" class="sr1-element"><?php UBC_Collab_Theme_Options::text('arts-social-column1-instagram', 'Instagram User'); ?></div>
-                <div id="sr1-facebook" class="sr1-element"><?php UBC_Collab_Theme_Options::text('arts-social-column1-facebook', 'Facebook Page URL'); ?></div>
                 <div id="sr1-flickr" class="sr1-element"><?php UBC_Collab_Theme_Options::text('arts-social-column1-flickr', 'Flickr User ID'); ?><br><span><a href="http://idgettr.com/" target="_blank">Find Flickr Id</a></span></div>
                 <div id="sr1-rss" class="sr1-element"><?php UBC_Collab_Theme_Options::text('arts-social-column1-rss', 'RSS URL'); ?></div>
                 <div id="sr1-text" class="sr1-element"><?php UBC_Collab_Theme_Options::textarea('arts-social-column1-content', 'Content'); ?></div>
@@ -389,8 +387,6 @@ Class UBC_FOA_Theme_Options {
                 </div>
                 <div id="sr2-posts" class="sr2-element"><label>Choose a category</label><br><?php UBC_Collab_Theme_Options::select_categories('arts-social-column2-post-category'); ?></div>
                 <div id="sr2-twitter" class="sr2-element"><?php UBC_Collab_Theme_Options::text('arts-social-column2-twitter-widget-id', 'Twitter Widget ID'); ?><br><?php UBC_Collab_Theme_Options::text('arts-social-column2-twitter-user', 'Twitter User'); ?><br><?php UBC_Collab_Theme_Options::text('arts-social-column2-twitter-url', 'Twitter Page URL'); ?></div>
-                <div id="sr2-instagram" class="sr2-element"><?php UBC_Collab_Theme_Options::text('arts-social-column2-instagram', 'Instagram User'); ?></div>
-                <div id="sr2-facebook" class="sr2-element"><?php UBC_Collab_Theme_Options::text('arts-social-column2-facebook', 'Facebook Page URL'); ?></div>
                 <div id="sr2-flickr" class="sr2-element"><?php UBC_Collab_Theme_Options::text('arts-social-column2-flickr', 'Flickr User ID'); ?><br><span><a href="http://idgettr.com/" target="_blank">Find Flickr Id</a></span></div>
                 <div id="sr2-rss" class="sr2-element"><?php UBC_Collab_Theme_Options::text('arts-social-column2-rss', 'RSS URL'); ?></div>
                 <div id="sr2-text" class="sr2-element"><?php UBC_Collab_Theme_Options::textarea('arts-social-column2-content', 'Content'); ?></div>
@@ -415,8 +411,6 @@ Class UBC_FOA_Theme_Options {
                 </div>
                 <div id="sr3-posts" class="sr3-element"><label>Choose a category</label><br><?php UBC_Collab_Theme_Options::select_categories('arts-social-column3-post-category'); ?></div>
                 <div id="sr3-twitter" class="sr3-element"><?php UBC_Collab_Theme_Options::text('arts-social-column3-twitter-widget-id', 'Twitter Widget ID'); ?><br><?php UBC_Collab_Theme_Options::text('arts-social-column3-twitter-user', 'Twitter User'); ?><br><?php UBC_Collab_Theme_Options::text('arts-social-column3-twitter-url', 'Twitter Page URL'); ?></div>
-                <div id="sr3-instagram" class="sr3-element"><?php UBC_Collab_Theme_Options::text('arts-social-column3-instagram', 'Instagram User'); ?></div>
-                <div id="sr3-facebook" class="sr3-element"><?php UBC_Collab_Theme_Options::text('arts-social-column3-facebook', 'Facebook Page URL'); ?></div>
                 <div id="sr3-flickr" class="sr3-element"><?php UBC_Collab_Theme_Options::text('arts-social-column3-flickr', 'Flickr User ID'); ?><br><span><a href="http://idgettr.com/" target="_blank">Find Flickr Id</a></span></div>
                 <div id="sr3-rss" class="sr3-element"><?php UBC_Collab_Theme_Options::text('arts-social-column3-rss', 'RSS URL'); ?></div>
                 <div id="sr3-text" class="sr3-element"><?php UBC_Collab_Theme_Options::textarea('arts-social-column3-content', 'Content'); ?></div>


### PR DESCRIPTION
Submitting a pull request as well as a request to deploy this change to production UBC CMS in order to resolve INC1951830.

An excerpt of the ticket above:

"

...
As per our conversation, since Facebook and Instagram will be updating their API to prevent unauthorized embeds from displaying as of October 24, 2020, would it be possible to remove those two options from the dropdown available via "FOA options" under Appearance > Theme Options for those UBC CMS sites making use of the UBC FOA Website plugin?  Thank you!
...
